### PR TITLE
Add support for bash language

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "LeetHub v3",
   "description": "Automatically integrate your Leetcode & GeeksforGeeks submissions to GitHub",
   "homepage_url": "https://github.com/raphaelheinz/LeetHub-3.0",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "author": "Raphael Heinz",
   "action": {
     "default_icon": "assets/thumbnail.png",

--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -3,6 +3,7 @@ const languages = {
   C: '.c',
   'C++': '.cpp',
   'C#': '.cs',
+  Bash: '.sh',
   Dart: '.dart',
   Elixir: '.ex',
   Erlang: '.erl',


### PR DESCRIPTION
Currently the push to git feature fails for problems like [193. Valid Phone Numbers](https://leetcode.com/problems/valid-phone-numbers/description/) and [195. Tenth Line](https://leetcode.com/problems/tenth-line/description/) because the only available language is bash.
This PR addresses that.