### PR TITLE
feat: custom commit messages

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -33,3 +33,92 @@ body {
   padding-top: 2%;
   font-size: medium;
 }
+
+#toggle-icon {
+  font-size: 10px;
+  width: 20px;
+  height: 20px;
+  background-color: transparent;
+  transition: transform 0.3s ease;
+  display: inline-block;
+  cursor: pointer;
+}
+
+#toggle-icon:hover {
+  background-color: #cfc9c980 !important;
+}
+
+#toggle-icon.open {
+  transform: rotate(90deg);
+}
+
+#customize-btn {
+  margin-top: 1em;
+  border: none;
+  background-color: transparent;
+}
+
+#customize-message-container {
+  border: 1px dotted black;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+.setting-btns {
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #000;
+  box-sizing: border-box;
+  color: #000;
+  cursor: pointer;
+  display: inline-flex;
+  fill: #000;
+  justify-content: center;
+  letter-spacing: -.8px;
+  outline: 0;
+  padding: 0 17px;
+  text-align: center;
+  text-decoration: none;
+  transition: all .3s;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+#custom-commit-msg {
+  width: 100%;
+  padding: 12px 20px;
+  box-sizing: border-box;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+  background-color: #f8f8f8;
+  font-size: 16px;
+  resize: none;
+}
+
+.commit-variable {
+  box-sizing: border-box;
+  background-color: #a8dadc;
+  border: none;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border: 1px solid black;
+  margin: 2px;
+}
+
+.commit-variable:hover {
+  background-color: #457b9d;
+}
+
+#success-message {
+  color: green;
+  font-size: 14px;
+  display: none;
+}

--- a/popup.html
+++ b/popup.html
@@ -84,6 +84,28 @@
             </span>
           </p>
 
+          <!-- Toggle custom commit menu -->
+          <span id="toggle-icon">&#9654;</span> Customize Commit Message
+          
+          <div id="customize-message-container" style="display: none;">
+            <label for="variables">Available Variables</label>
+            <div id="variales">
+              <button class="commit-variable" id="time">Time (Time Percentile)</button>
+              <button class="commit-variable" id="space">Space (Space Percentile)</button>
+              <button class="commit-variable" id="date">Today's Date</button>
+              <button class="commit-variable" id="problemName">Problem Name</button>
+              <button class="commit-variable" id="difficulty">Difficulty</button>
+              <button class="commit-variable" id="language">Solved Language</button>
+            </div>
+            <textarea rows="4" id="custom-commit-msg" placeholder="Time: {time}, Space: {space} - LeetHub"></textarea>
+            <div id="setting-btns">
+              <button class="setting-btns" id="msg-reset-btn">Reset</button>
+              <button class="setting-btns" id="msg-save-btn">Save</button>
+              <br />
+              <span id="success-message">Commit message saved!</span>
+            </div>
+          </div>
+
           <div class="ui small header">
             Want more features?
             <a

--- a/popup.js
+++ b/popup.js
@@ -19,6 +19,48 @@ $('#hook_URL').attr(
   chrome.runtime.getURL('welcome.html')
 );
 
+$('#toggle-icon').click(() => {
+  $('#toggle-icon').toggleClass('open');
+  $('#customize-message-container').toggle(); 
+  chrome.storage.local.get(['custom_commit_message'], (data) => {
+    console.log("data after toggling", data)
+    let commitMessage = data.custom_commit_message;
+
+    // if null, undefined, or an empty string, set default placeholder
+    if (!commitMessage) {
+      $('#custom-commit-msg').attr('placeholder', "Time: {time}, Space: {space} - LeetHub");
+    } else {
+      $('#custom-commit-msg').attr('placeholder', commitMessage);
+      $('#custom-commit-msg').val(commitMessage);
+    }
+  });
+});
+
+$('#msg-save-btn').click(() => {
+  const commitMessage = $('#custom-commit-msg').val();
+  chrome.runtime.sendMessage({ action: 'customCommitMessageUpdated', message: commitMessage.trim() });
+
+  const successMessage = $('#success-message');
+  successMessage.show();
+  setTimeout(() => {
+    successMessage.hide();
+  }, 3000)
+});
+
+$('#msg-reset-btn').click(() => {
+  $("#custom-commit-msg").val("")
+  $('#custom-commit-msg').attr('placeholder', "Time: {time}, Space: {space} - LeetHub"); // reset to default
+  chrome.runtime.sendMessage({ action: 'customCommitMessageUpdated', message: null });
+})
+
+/* when variable is clicked, add to custom commit message text area*/
+$('.commit-variable').on('click', function() {
+  var variableName = $(this).attr('id');
+  $('#custom-commit-msg').val(function(index, currentValue) {
+    return currentValue + `{${variableName}} `;
+  });
+});
+
 chrome.storage.local.get('leethub_token', (data) => {
   const token = data.leethub_token;
   if (token === null || token === undefined) {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,4 +1,8 @@
 function handleMessage(request) {
+  if (request.action === 'customCommitMessageUpdated') {
+    chrome.storage.local.set({ custom_commit_message: request.message })
+  }
+  
   if ( request && request.closeWebPage === true && request.isSuccess === true ) {
     /* Set username */
     chrome.storage.local.set({ leethub_username: request.username });


### PR DESCRIPTION
This introduces a feature for custom commits. This addresses a part of this issue: https://github.com/raphaelheinz/LeetHub-3.0/issues/36#issue-2339821686 as well

The caveat is this feature is only implemented for Leetcode V2.
<img width="343" alt="Screenshot 2025-03-07 at 7 59 49 PM" src="https://github.com/user-attachments/assets/f11eb600-5488-4359-a007-5d13c8050137" />

Users can add their own text to the commit message and some set variables as well
<img width="939" alt="Screenshot 2025-03-07 at 8 01 18 PM" src="https://github.com/user-attachments/assets/4073393c-e0f9-430d-b59f-268afc1985a5" />

