### PR TITLE
Add support for saving submissions in LeetCode/{Difficulty}/ sub-folders

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -41,6 +41,23 @@ body {
   cursor: pointer;
 }
 
+#toggle-folder-icon {
+  font-size: 10px;
+  width: 20px;
+  height: 20px;
+  background-color: transparent;
+  transition: transform 0.3s ease;
+  display: inline-block;
+  cursor: pointer;
+}
+#toggle-folder-icon:hover {
+  background-color: #cfc9c980 !important;
+}
+
+#toggle-folder-icon.open {
+  transform: rotate(90deg);
+}
+
 #toggle-icon:hover {
   background-color: #cfc9c980 !important;
 }
@@ -56,6 +73,14 @@ body {
 }
 
 #customize-message-container {
+  border: 1px dotted black;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+#difficulty-folder-container {
   border: 1px dotted black;
   padding: 1em;
   display: flex;

--- a/popup.html
+++ b/popup.html
@@ -105,6 +105,20 @@
               <span id="success-message">Commit message saved!</span>
             </div>
           </div>
+          <!-- Toggle useDifficultyFolder setting -->
+          <div>
+            <span id="toggle-folder-icon">&#9654;</span> Use Difficulty Subfolder
+
+            <div id="difficulty-folder-container" style="display: none">
+              <p>Organize files into folders like <code>LeetCode/Easy/0001-two-sum.js</code></p>
+              <div class="centered-toggle">
+                <div class="ui toggle checkbox">
+                  <input type="checkbox" id="use-difficulty-folder" />
+                  <label for="use-difficulty-folder"></label>
+                </div>
+              </div>
+            </div>
+          </div>
 
           <div class="ui small header">
             Want more features?

--- a/popup.js
+++ b/popup.js
@@ -36,6 +36,23 @@ $('#toggle-icon').click(() => {
   });
 });
 
+// Toggle difficulty folder section
+$('#toggle-folder-icon').click(() => {
+  $('#toggle-folder-icon').toggleClass('open');
+  $('#difficulty-folder-container').toggle();
+
+  // Load from storage: use default value 'false' if not set
+  chrome.storage.local.get({ useDifficultyFolder: false }, data => {
+    $('#use-difficulty-folder').prop('checked', data.useDifficultyFolder);
+  });
+});
+
+// Store Switch State
+$('#use-difficulty-folder').change(function () {
+  const isChecked = $(this).is(':checked');
+  chrome.storage.local.set({ useDifficultyFolder: isChecked });
+});
+
 $('#msg-save-btn').click(() => {
   const commitMessage = $('#custom-commit-msg').val();
   chrome.runtime.sendMessage({ action: 'customCommitMessageUpdated', message: commitMessage.trim() });


### PR DESCRIPTION
<div align="center">
  <img width="368" alt="image" src="https://github.com/user-attachments/assets/8bc18c98-e20d-4fed-823f-39f015cb9113" />
</div>


### 🎯 What does this PR do?

This PR implements **custom sub-folder routing** support for saving LeetCode submissions, based on the problem’s difficulty.

Instead of saving files directly to the root of the repository like:

```
/0001-two-sum.js
```

it now supports a structured path like:

```
/LeetCode/Easy/0001-two-sum.js
```

This is controlled by the `useDifficultyFolder` setting, which is **loaded from `chrome.storage.local`**. If no setting is found, the default is `false`.

The path is dynamically built using:

```js
constructGitHubPath(hook, basePath, difficulty, problem, filename, useDifficultyFolder)
```

---

### 💡 Motivation

While using LeetHub myself, I wanted a more organized folder structure for reviewing problems later on. Having submissions sorted by difficulty (`Easy`, `Medium`, `Hard`) inside a `LeetCode/` folder makes things much easier to manage — especially when the number of solved problems grows.

I figured this could be helpful to others as well, so I decided to contribute this change back.

---

### 🙏 Acknowledgement

This implementation was heavily inspired by [@suzyvaque](https://github.com/suzyvaque)’s suggestion in [Issue #48](https://github.com/raphaelheinz/LeetHub-3.0/issues/48).  
I referenced parts of her code and successfully implemented the feature with that as a base.  
Big thanks to her for openly sharing her idea and work — it really helped move this forward! 💙