### PR TITLE
fix: skip duplicate "Add to topics" commit on repeated submissions

### DIFF
--- a/src/js/leetcode.js
+++ b/src/js/leetcode.js
@@ -212,8 +212,15 @@ async function updateReadmeTopicTagsWithProblem(topicTags, problemName) {
     }
   }
 
+  const readmeBeforeProcessing = readme;
+
   for (const topic of topicTags) {
     readme = await appendProblemToReadme(topic.name, readme, leethub_hook, problemName);
+  }
+
+  if (readme === readmeBeforeProcessing) {
+    console.log(`No README changes detected for ${problemName}, skipping topics upload.`);
+    return;
   }
 
   readme = sortTopicsInReadme(readme);


### PR DESCRIPTION
Problem

When a LeetCode solution is submitted multiple times (e.g. resubmitting an already-accepted problem), LeetHub creates an extra git commit with the message Add <problem> to topics. on every submission — even though the problem was already present in the README topic tables and nothing actually changed.

Blank extra commit on every submission
<img width="866" height="296" alt="image" src="https://github.com/user-attachments/assets/e581268c-e68b-40ff-ac75-04802bfbf4af" />


Fix

Snapshot the README content before the append loop. After the loop — but before calling sortTopicsInReadme — compare the result to the snapshot. If the content is identical (nothing new was added), exit early and skip both sorting and uploading entirely.