### PR TITLE
Add "Change Repository" button to popup

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -56,6 +56,14 @@
             <span id="p_solved_hard" style="color: #000000; opacity: 0.75">0 </span>
           </p>
 
+          <!-- Change Repository -->
+          <div style="margin: 1em 0">
+            <a id="change_repo_URL" href="" target="_blank" class="ui secondary button">
+              <i class="icon github"></i>
+              Change Repository
+            </a>
+          </div>
+
           <!-- Toggle custom commit menu -->
           <span id="collapsible-commit-message-icon" class="collapsible-icon">&#9654;</span>
           Customize Commit Message

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -12,6 +12,8 @@ $('#welcome_URL').attr('href', chrome.runtime.getURL('src/html/welcome.html'));
 
 $('#hook_URL').attr('href', chrome.runtime.getURL('src/html/welcome.html'));
 
+$('#change_repo_URL').attr('href', chrome.runtime.getURL('src/html/welcome.html'));
+
 $('#collapsible-commit-message-icon').click(() => {
   $('#collapsible-commit-message-icon').toggleClass('open');
   $('#collapsible-commit-message-container').toggle();


### PR DESCRIPTION
Closes Issue #70.

Currently, switching the linked GitHub repo requires uninstalling and reinstalling the extension. This PR adds a Change Repository button to the popup (visible in commit mode, below the solved stats) that opens the existing welcome.html page in a new tab, where users can already unlink the current repo and create or link a new one.