### PR TITLE
Implement getNotesIfAny to sync LeetCode private Notes to NOTES.md

### DIFF
--- a/src/js/leetcode.js
+++ b/src/js/leetcode.js
@@ -1582,16 +1582,17 @@ const loader = (leetCode, suffix) => {
         fileName = suffix ? `${problemName}${suffix}${language}` : `${problemName}${language}`;
       }
 
+      /* Wait for notes upload before continuing, to avoid a GitHub commit race */
+      await updateNotes;
+
       /* Upload code to Git */
-      const updateCode = leetCode.findAndUploadCode(problemName, fileName, commitMsg, 'upload');
+      const updateCode = await leetCode.findAndUploadCode(problemName, fileName, commitMsg, 'upload');
 
       /* Group problem into its relevant topics */
-      const updateRepoReadMe = updateReadmeTopicTagsWithProblem(
+      const updateRepoReadMe = await updateReadmeTopicTagsWithProblem(
         leetCode.questionDetails?.topicTags,
         problemName
       );
-
-      await Promise.all([updateReadMe, updateNotes, updateCode, updateRepoReadMe]);
 
       uploadState.uploading = false;
       leetCode.markUploaded();

--- a/src/js/leetcode.js
+++ b/src/js/leetcode.js
@@ -1216,7 +1216,35 @@ LeetCodeV2.prototype.getLanguage = function () {
   return '';
 };
 
-LeetCodeV2.prototype.getNotesIfAny = function () {};
+LeetCodeV2.prototype.getNotesIfAny = async function () {
+  const titleSlug = this.submissionData?.question?.titleSlug;
+  if (!titleSlug) return '';
+
+  const noteQuery = {
+    query:
+      '\n    query questionNote($titleSlug: String!) {\n  question(titleSlug: $titleSlug) {\n    questionId\n    note\n  }\n}\n    ',
+    variables: { titleSlug },
+    operationName: 'questionNote',
+  };
+
+  const noteOptions = {
+    method: 'POST',
+    headers: {
+      cookie: document.cookie,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(noteQuery),
+  };
+
+  try {
+    const res = await fetch(`${getLeetCodeBaseUrl()}/graphql/`, noteOptions);
+    const data = await res.json();
+    return data?.data?.question?.note || '';
+  } catch (err) {
+    console.log('LeetHub: Error fetching notes', err);
+    return '';
+  }
+};
 
 LeetCodeV2.prototype.extractQuestionNumber = function () {
   return this.submissionData.question.questionFrontendId ?? this.submissionData.question.questionId;
@@ -1516,7 +1544,7 @@ const loader = (leetCode, suffix) => {
       });
 
       /* Upload Notes if any*/
-      let notes = leetCode.getNotesIfAny();
+      let notes = await leetCode.getNotesIfAny();
       let updateNotes;
       if (notes != undefined && notes.length > 0) {
         updateNotes = uploadGit(


### PR DESCRIPTION
Closes #106

See linked issue for full details. Summary of changes in src/js/leetcode.js:
- Implemented `getNotesIfAny()` to fetch private LeetCode notes via the `questionNote` GraphQL query and commit them as NOTES.md
- Changed the parallel `Promise.all` upload of README/Notes/Code/RepoReadme to sequential awaits to fix an intermittent 409 conflict on GitHub's contents API

Tested manually on Firefox with a real LeetCode account and a test GitHub repo across multiple problems.